### PR TITLE
pretty-hydra: better dynamic hint support

### DIFF
--- a/Cask
+++ b/Cask
@@ -6,4 +6,6 @@
 
 (development
  (depends-on "hydra")
+ (depends-on "dash")
+ (depends-on "dash-functional")
  (depends-on "ert-runner"))

--- a/major-mode-hydra.el
+++ b/major-mode-hydra.el
@@ -4,7 +4,7 @@
 
 ;; Author: Jerry Peng <pr2jerry@gmail.com>
 ;; URL: https://github.com/jerrypnz/major-mode-hydra.el
-;; Version: 0.1.0
+;; Version: 0.1.1
 ;; Package-Requires: ((dash "2.15.0") (pretty-hydra "0.1.1") (emacs "25"))
 
 ;; This file is NOT part of GNU Emacs.

--- a/major-mode-hydra.el
+++ b/major-mode-hydra.el
@@ -5,7 +5,7 @@
 ;; Author: Jerry Peng <pr2jerry@gmail.com>
 ;; URL: https://github.com/jerrypnz/major-mode-hydra.el
 ;; Version: 0.1.0
-;; Package-Requires: ((dash "2.12.1") (pretty-hydra "0.1.0") (emacs "25"))
+;; Package-Requires: ((dash "2.15.0") (pretty-hydra "0.1.1") (emacs "25"))
 
 ;; This file is NOT part of GNU Emacs.
 

--- a/pretty-hydra.el
+++ b/pretty-hydra.el
@@ -207,6 +207,19 @@ docstring."
        ,docstring
        ,@heads)))
 
+;;;###autoload
+(defun pretty-hydra-radio (name status)
+  "Create a dynamic hint that look like a radio button with given NAME.
+Radio is considered on when STATUS is non-nil, otherwise off."
+  (s-concat name " " (if status
+                         (propertize "(*)" 'face 'font-lock-keyword-face)
+                       (propertize "( )" 'face 'font-lock-comment-face))))
+
+;;;###autoload
+(defmacro pretty-hydra-mode-radio (name mode)
+  "Create a radio hint for given MODE with given NAME."
+  `(pretty-hydra-radio ,name (bound-and-true-p ,mode)))
+
 (provide 'pretty-hydra)
 
 ;;; pretty-hydra.el ends here

--- a/pretty-hydra.el
+++ b/pretty-hydra.el
@@ -69,15 +69,15 @@
   "Pad or truncate HINT to LEN, preserving text properties."
   (if (null hint)
       hint
-    (let* ((len1 (length hint))
-           (props (text-properties-at 0 hint))
-           (hint1 (cond
-                   ((> len1 len) (s-truncate len hint))
-                   ((< len1 len) (s-pad-right len " " hint))
-                   (t hint))))
-      (when props
-        (set-text-properties 0 len props hint1))
-      hint1)))
+    (let ((len1 (length hint))
+          (props (text-properties-at 0 hint)))
+      (cond
+       ((> len1 len) (let ((x (s-truncate len hint)))
+                       (when props
+                         (set-text-properties 0 len props x))
+                       x))
+       ((< len1 len) (s-pad-right len " " hint))
+       (t            hint)))))
 
 (defun pretty-hydra--cell-docstring (width head)
   "Generate docstring for a HEAD with given WIDTH."

--- a/test/major-mode-hydra-test.el
+++ b/test/major-mode-hydra-test.el
@@ -1,4 +1,4 @@
-;;; major-mode-hydra-tests.el --- Tests for major-mode-hydra  -*- lexical-binding: t; -*-
+;;; major-mode-hydra-test.el --- Tests for major-mode-hydra  -*- lexical-binding: t; -*-
 
 ;; Copyright (C) 2018 Jerry Peng
 
@@ -27,35 +27,35 @@
 
 (require 'major-mode-hydra)
 
-(ert-deftest major-mode-hydra-tests--bind-key--empty-heads-alist ()
+(ert-deftest major-mode-hydra-test--bind-key--empty-heads-alist ()
   (let ((major-mode-hydra--heads-alist nil))
     (major-mode-hydra-bind emacs-lisp-mode "Test Emacs"
       ("v" emacs-version "Emacs Version"))
     (should (equal major-mode-hydra--heads-alist
                    '((emacs-lisp-mode ("Test Emacs" "v" emacs-version "Emacs Version")))))))
 
-(ert-deftest major-mode-hydra-tests--bind-key--cmd-name-as-hint ()
+(ert-deftest major-mode-hydra-test--bind-key--cmd-name-as-hint ()
   (let ((major-mode-hydra--heads-alist nil))
     (major-mode-hydra-bind emacs-lisp-mode "Test Emacs"
       ("v" emacs-version))
     (should (equal major-mode-hydra--heads-alist
                    '((emacs-lisp-mode ("Test Emacs" "v" emacs-version "emacs-version")))))))
 
-(ert-deftest major-mode-hydra-tests--bind-key--head-opts ()
+(ert-deftest major-mode-hydra-test--bind-key--head-opts ()
   (let ((major-mode-hydra--heads-alist nil))
     (major-mode-hydra-bind emacs-lisp-mode "Test Emacs"
       ("v" emacs-version :exit nil :color red))
     (should (equal major-mode-hydra--heads-alist
                    '((emacs-lisp-mode ("Test Emacs" "v" emacs-version "emacs-version" :exit nil :color red)))))))
 
-(ert-deftest major-mode-hydra-tests--bind-key--hint-and-head-opts ()
+(ert-deftest major-mode-hydra-test--bind-key--hint-and-head-opts ()
   (let ((major-mode-hydra--heads-alist nil))
     (major-mode-hydra-bind emacs-lisp-mode "Test Emacs"
       ("v" emacs-version "Emacs Version" :exit nil :color red))
     (should (equal major-mode-hydra--heads-alist
                    '((emacs-lisp-mode ("Test Emacs" "v" emacs-version "Emacs Version" :exit nil :color red)))))))
 
-(ert-deftest major-mode-hydra-tests--bind-key--add-head-to-existing-column ()
+(ert-deftest major-mode-hydra-test--bind-key--add-head-to-existing-column ()
   (let ((major-mode-hydra--heads-alist '((emacs-lisp-mode ("Test Emacs" "v" emacs-version "emacs-version")))))
     (major-mode-hydra-bind emacs-lisp-mode "Test Emacs"
       ("b" foobar "Foobar"))
@@ -63,7 +63,7 @@
                    '((emacs-lisp-mode ("Test Emacs" "b" foobar "Foobar")
                                       ("Test Emacs" "v" emacs-version "emacs-version")))))))
 
-(ert-deftest major-mode-hydra-tests--bind-key--new-column ()
+(ert-deftest major-mode-hydra-test--bind-key--new-column ()
   (let ((major-mode-hydra--heads-alist '((emacs-lisp-mode ("Test Emacs" "v" emacs-version "emacs-version")))))
     (major-mode-hydra-bind emacs-lisp-mode "Foo"
       ("b" foobar "Foobar"))
@@ -71,34 +71,34 @@
                    '((emacs-lisp-mode ("Foo"        "b" foobar "Foobar")
                                       ("Test Emacs" "v" emacs-version "emacs-version")))))))
 
-(ert-deftest major-mode-hydra-tests--bind-key--duplicate-key ()
+(ert-deftest major-mode-hydra-test--bind-key--duplicate-key ()
   (let ((major-mode-hydra--heads-alist '((emacs-lisp-mode ("Test Emacs" "v" emacs-version "emacs-version")))))
     (major-mode-hydra-bind emacs-lisp-mode "Test Emacs"
       ("v" foobar "Foobar"))
     (should (equal major-mode-hydra--heads-alist
                    '((emacs-lisp-mode  ("Test Emacs" "v" emacs-version "emacs-version")))))))
 
-(ert-deftest major-mode-hydra-tests--bind-key--nil-cmd ()
+(ert-deftest major-mode-hydra-test--bind-key--nil-cmd ()
   (let ((major-mode-hydra--heads-alist nil))
     (major-mode-hydra-bind emacs-lisp-mode "Test Emacs"
       ("q" nil "quit"))
     (should (equal major-mode-hydra--heads-alist
                    '((emacs-lisp-mode ("Test Emacs" "q" nil "quit")))))))
 
-(ert-deftest major-mode-hydra-tests--bind-key--nil-cmd-no-hint ()
+(ert-deftest major-mode-hydra-test--bind-key--nil-cmd-no-hint ()
   (let ((major-mode-hydra--heads-alist nil))
     (major-mode-hydra-bind emacs-lisp-mode "Test Emacs"
       ("q" nil))
     (should (equal major-mode-hydra--heads-alist
                    '((emacs-lisp-mode ("Test Emacs" "q" nil "nil")))))))
 
-(ert-deftest major-mode-hydra-tests--bind-key--invisibe-quit ()
+(ert-deftest major-mode-hydra-test--bind-key--invisibe-quit ()
   (let* ((major-mode-hydra--heads-alist '((emacs-lisp-mode ("Test Emacs" "v" emacs-version "emacs-version"))))
          (major-mode-hydra-invisible-quit-key "q"))
     (major-mode-hydra-bind emacs-lisp-mode "Test Emacs"
       ("q" foobar "foobar"))
     (should (equal major-mode-hydra--heads-alist '((emacs-lisp-mode ("Test Emacs" "v" emacs-version "emacs-version")))))))
 
-(provide 'major-mode-hydra-tests)
+(provide 'major-mode-hydra-test)
 
-;;; major-mode-hydra-tests.el ends here
+;;; major-mode-hydra-test.el ends here

--- a/test/pretty-hydra-test.el
+++ b/test/pretty-hydra-test.el
@@ -1,0 +1,72 @@
+;;; pretty-hydra-test.el --- Tests for pretty-hydra  -*- lexical-binding: t; -*-
+
+;; Copyright (C) 2019 Jerry Peng
+
+;; Author: Jerry Peng <pr2jerry@gmail.com>
+
+;; This file is NOT part of GNU Emacs.
+
+;; This program is free software; you can redistribute it and/or
+;; modify it under the terms of the GNU General Public License as
+;; published by the Free Software Foundation; either version 3, or (at
+;; your option) any later version.
+;;
+;; This program is distributed in the hope that it will be useful, but
+;; WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+;; General Public License for more details.
+;;
+;; You should have received a copy of the GNU General Public License
+;; along with GNU Emacs; see the file COPYING.  If not, write to the
+;; Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+;; Boston, MA 02110-1301, USA.
+
+;;; Commentary:
+
+;;; Code:
+
+(require 'pretty-hydra)
+
+(ert-deftest pretty-hydra-test--calc-column-width ()
+  (dolist (test '((10 "C1" (("a" nil "c1")))
+                  (28 "C1" (("a" nil (foobar) :width 20)))
+                  (28 "C1" (("a" nil foobar :width 20)))
+                  (13 "Long Column" (("a" nil "c1")))
+                  (4 "C1" (("a" nil)))
+                  (28 "C1" (("a" nil (foo))))))
+    (-let [(expected col-name heads) test]
+      (should (equal expected (pretty-hydra--calc-column-width col-name heads))))))
+
+(ert-deftest pretty-hydra-test--normalize-head ()
+  (dolist (test '((("a" nil "c1") . ("a" nil "c1"))
+                  (("a" nil)   . ("a" nil))
+                  (("a" nil "c1" :exit t) . ("a" nil "c1" :exit t))
+                  (("a" nil nil :exit t) . ("a" nil :exit t))))
+    (-let [(expected . head) test]
+      (should (equal expected (pretty-hydra--normalize-head head))))))
+
+(ert-deftest pretty-hydra-test--cell-docstring ()
+  (dolist (test '(((" [_a_] c1           ") . ("a" nil "c1"))
+                  ((" [_a_] %s(pretty-hydra--pad-or-trunc-hint c1 13)") . ("a" nil c1))
+                  ((" [_a_] %s(pretty-hydra--pad-or-trunc-hint (c1) 13)") . ("a" nil (c1)))
+                  ((" [_a_] %s(pretty-hydra--pad-or-trunc-hint (c1 (quote foo)) 13)") . ("a" nil (c1 'foo)))
+                  (nil   . ("a" nil))))
+    (-let [(expected . head) test]
+      (should (equal expected (pretty-hydra--cell-docstring 20 head))))))
+
+(ert-deftest pretty-hydra-test--get-heads ()
+  (should (equal '(("a" foo)
+                   ("b" bar :exit t)
+                   ("c" foobar :exit nil)
+                   ("d" barfoo))
+                 (pretty-hydra--get-heads
+                  '("C1"
+                    (("a" foo "foo")
+                     ("b" bar nil :exit t :width 20))
+                    "C2"
+                    (("c" foobar (foo) :width 20 :exit nil)
+                     ("d" barfoo)))))))
+
+(provide 'pretty-hydra-test)
+
+;;; pretty-hydra-test.el ends here


### PR DESCRIPTION
- properly truncate/pad dynamic hint
- use string interpolation instead of the `?key?` syntax
  - this also fix duplicate hint issue under latest version of hydra
- ppdate packages to newer versions
- add tests