### PR TITLE
Added pretty-hydra-define+

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,6 +224,21 @@ The following is an example toggles hydra:
 The on/off faces can be customized through
 `pretty-hydra-toggle-on-face` and `pretty-hydra-toggle-off-face`.
 
+You can use `pretty-hydra-define+` in order to add heads to an already existing
+`pretty-hydra`. New heads are appended to existing columns, if their names match
+(otherwise new columns are created). Here's an example redefining the
+`jp-window` hydra we created above.
+
+```elisp
+(pretty-hydra-define+ jp-window ()
+  (;; these heads are added to the existing "Windows" column
+   "Windows" (("r" transpose-frame "rotate")
+              ("z" zone "zone out!"))
+   ;; this is a new column, which gets added
+   "Appearance" (("f" set-frame-font "font")
+                 ("t" load-theme "theme"))))
+```
+
 ## License
 
 Copyright © 2018 Jerry Peng

--- a/pretty-hydra.el
+++ b/pretty-hydra.el
@@ -175,6 +175,37 @@ The result is a new plist."
                    (append (lax-plist-get old new-column)
                            (lax-plist-get new new-column)))))
 
+(defun pretty-hydra--generate (name body heads-plist func)
+  "Helper function to generate hydras.
+See `pretty-hydra-define'."
+  (let* ((separator (or (plist-get body :separator) "─"))
+         (title     (plist-get body :title))
+         (formatter (or (plist-get body :formatter)
+                        #'identity))
+         (quit-key  (plist-get body :quit-key))
+         (docstring (->> heads-plist
+                         (pretty-hydra--gen-body-docstring separator)
+                         (pretty-hydra--maybe-add-title title)
+                         (funcall formatter)
+                         (s-prepend "\n"))) ;; This is required, otherwise the docstring won't show up correctly
+         (heads (pretty-hydra--get-heads heads-plist))
+         (heads (if quit-key
+                    (append heads `((,quit-key nil)))
+                  heads))
+         (body (pretty-hydra--remove-custom-opts body)))
+    `(progn
+       (set (defvar ,(intern (format "%S/heads-plist" name))
+              nil
+              ,(format "heads-plist of %S." name))
+            (quote ,heads-plist))
+       (set (defvar ,(intern (format "%S/pretty-body" name))
+              nil
+              ,(format "pretty-body of %S." name))
+            (quote ,body))
+       (,func ,name ,body
+              ,docstring
+              ,@heads))))
+
 ;;;###autoload
 (defmacro pretty-hydra-define (name body heads-plist)
   "Define a pretty hydra with given NAME, BODY options and HEADS-PLIST.
@@ -206,33 +237,7 @@ hydra heads.  Each head has exactly the same syntax as that of
 `defhydra', except hint is required for the head to appear in the
 docstring."
   (declare (indent defun))
-  (let* ((separator (or (plist-get body :separator) "─"))
-         (title     (plist-get body :title))
-         (formatter (or (plist-get body :formatter)
-                        #'identity))
-         (quit-key  (plist-get body :quit-key))
-         (docstring (->> heads-plist
-                         (pretty-hydra--gen-body-docstring separator)
-                         (pretty-hydra--maybe-add-title title)
-                         (funcall formatter)
-                         (s-prepend "\n"))) ;; This is required, otherwise the docstring won't show up correctly
-         (heads (pretty-hydra--get-heads heads-plist))
-         (heads (if quit-key
-                    (append heads `((,quit-key nil)))
-                  heads))
-         (body (pretty-hydra--remove-custom-opts body)))
-    `(progn
-       (set (defvar ,(intern (format "%S/heads-plist" name))
-              nil
-              ,(format "heads-plist of %S." name))
-            (quote ,heads-plist))
-       (set (defvar ,(intern (format "%S/pretty-body" name))
-              nil
-              ,(format "pretty-body of %S." name))
-            (quote ,body))
-       (defhydra ,name ,body
-         ,docstring
-         ,@heads))))
+  (pretty-hydra--generate name body heads-plist 'defhydra))
 
 (defmacro pretty-hydra-define+ (name body heads-plist)
   "Redefine an existing pretty-hydra by adding new heads.
@@ -240,36 +245,12 @@ If heads are added to a column already in NAME, the heads are
 appended to that column.
 Arguments are same as of `pretty-hydra-define'."
   (declare (indent defun))
-  (let* ((body (or body (hydra--prop name "/pretty-body")))
-         (heads-plist (pretty-hydra--merge-plists
-                       (hydra--prop name "/heads-plist") heads-plist))
-         (separator (or (plist-get body :separator) "─"))
-         (title     (plist-get body :title))
-         (formatter (or (plist-get body :formatter)
-                        #'identity))
-         (quit-key  (plist-get body :quit-key))
-         (docstring (->> heads-plist
-                         (pretty-hydra--gen-body-docstring separator)
-                         (pretty-hydra--maybe-add-title title)
-                         (funcall formatter)
-                         (s-prepend "\n")))
-         (heads (pretty-hydra--get-heads heads-plist))
-         (heads (if quit-key
-                    (append heads `((,quit-key nil)))
-                  heads))
-         (body (pretty-hydra--remove-custom-opts body)))
-    `(progn
-       (set (defvar ,(intern (format "%S/heads-plist" name))
-              nil
-              ,(format "heads-plist of %S." name))
-            (quote ,heads-plist))
-       (set (defvar ,(intern (format "%S/pretty-body" name))
-              nil
-              ,(format "pretty-body of %S." name))
-            (quote ,body))
-       (defhydra+ ,name ,body
-         ,docstring
-         ,@heads))))
+  (pretty-hydra--generate
+   name
+   (or body (hydra--prop name "/pretty-body"))
+   (pretty-hydra--merge-plists
+    (hydra--prop name "/heads-plist") heads-plist)
+   'defhydra+))
 
 (defface pretty-hydra-toggle-on-face
   '((t (:inherit 'font-lock-keyword-face)))


### PR DESCRIPTION
See the updated README for how it is used.

pretty-hydra-define+ needs some extra "hydra-props" in order to know
which arguments were given to the original pretty-hydra-define.
Therefore pretty-hydra-define is changed to set the props
"/pretty-body" and "/heads-plist" to the pretty-hydra.