### PR TITLE
Look for a hydra of one of the ancestor major modes

### DIFF
--- a/major-mode-hydra.el
+++ b/major-mode-hydra.el
@@ -134,10 +134,14 @@ exactly the same structure as that in `pretty-hydra-define' or
 
 (defun major-mode-hydra-dispatch (mode)
   "Summon the hydra for given MODE (if there is one)."
-  (let ((hydra (major-mode-hydra--body-name-for mode)))
-    (if (fboundp hydra)
-        (call-interactively hydra)
-      (message "Major mode hydra not found for %s" mode))))
+  (catch 'done
+    (while mode
+      (let ((hydra (major-mode-hydra--body-name-for mode)))
+        (when (fboundp hydra)
+          (call-interactively hydra)
+          (throw 'done t)))
+      (setq mode (get-mode-local-parent mode)))
+    (user-error "Major mode hydra not found for %s" mode)))
 
 ;;;###autoload
 (defun major-mode-hydra ()

--- a/major-mode-hydra.el
+++ b/major-mode-hydra.el
@@ -134,14 +134,15 @@ exactly the same structure as that in `pretty-hydra-define' or
 
 (defun major-mode-hydra-dispatch (mode)
   "Summon the hydra for given MODE (if there is one)."
-  (catch 'done
-    (while mode
-      (let ((hydra (major-mode-hydra--body-name-for mode)))
-        (when (fboundp hydra)
-          (call-interactively hydra)
-          (throw 'done t)))
-      (setq mode (get-mode-local-parent mode)))
-    (user-error "Major mode hydra not found for %s" mode)))
+  (let ((orig-mode mode))
+    (catch 'done
+      (while mode
+        (let ((hydra (major-mode-hydra--body-name-for mode)))
+          (when (fboundp hydra)
+            (call-interactively hydra)
+            (throw 'done t)))
+        (setq mode (get mode 'derived-mode-parent)))
+      (user-error "Major mode hydra not found for %s or its parent modes" orig-mode))))
 
 ;;;###autoload
 (defun major-mode-hydra ()


### PR DESCRIPTION
With this patch, `major-mode-hydra` command looks for a hydra for an ancestor of the current major mode and dispatches it if any, when the original mode doesn't have a corresponding major mode defined.

For example, if you have a hydra for `org-mode` but not for `org-journal-mode`, then the hydra for `org-mode` is dispatched in `org-journal-mode`.