### PR TITLE
Replace deprecated dash-functional dependency

### DIFF
--- a/Cask
+++ b/Cask
@@ -7,6 +7,5 @@
 (development
  (depends-on "hydra")
  (depends-on "dash")
- (depends-on "dash-functional")
  (depends-on "use-package")
  (depends-on "ert-runner"))

--- a/major-mode-hydra.el
+++ b/major-mode-hydra.el
@@ -5,7 +5,7 @@
 ;; Author: Jerry Peng <pr2jerry@gmail.com>
 ;; URL: https://github.com/jerrypnz/major-mode-hydra.el
 ;; Version: 0.2.2
-;; Package-Requires: ((dash "2.15.0") (pretty-hydra "0.2.2") (emacs "25"))
+;; Package-Requires: ((dash "2.18.0") (pretty-hydra "0.2.2") (emacs "25"))
 
 ;; This file is NOT part of GNU Emacs.
 

--- a/pretty-hydra.el
+++ b/pretty-hydra.el
@@ -5,7 +5,7 @@
 ;; Author: Jerry Peng <pr2jerry@gmail.com>
 ;; URL: https://github.com/jerrypnz/major-mode-hydra.el
 ;; Version: 0.2.2
-;; Package-Requires: ((hydra "0.15.0") (s "1.12.0") (dash "2.15.0") (dash-functional "1.2.0") (emacs "24"))
+;; Package-Requires: ((hydra "0.15.0") (s "1.12.0") (dash "2.18.0") (emacs "24"))
 
 ;; This file is NOT part of GNU Emacs.
 
@@ -32,7 +32,6 @@
 ;;; Code:
 
 (require 'dash)
-(require 'dash-functional)
 (require 's)
 (require 'hydra)
 


### PR DESCRIPTION
Dash 2.18.0 now subsumes `dash-functional`.

See https://github.com/magnars/dash.el/blob/master/NEWS.md#from-217-to-218