### PR TITLE
Add customizable format-spec string for adding title to body

### DIFF
--- a/README.md
+++ b/README.md
@@ -315,6 +315,12 @@ options that allow you to customize the generated body docstring:
   function that takes the docstring `pretty-hydra-define` generates,
   and returns a new docstring that's gonna be used. You can do things
   like generating a border etc.
+- `:title-body-format-spec`. An format specification string that is formatted
+  with the title and the body of the hydra into a docstring. It is therefore
+  only used if `:title` is provided. It should contain two `%s`. It can be used
+  to customize the whitespace around and between the title and the body. Its
+  default can changed by customizing
+  `pretty-hydra-default-title-body-format-spec`.
 - `:quit-key` adds a invisible hydra head for quitting the hydra. It
   can be useful when you set `:foreign-keys` to `warn`.
 

--- a/pretty-hydra.el
+++ b/pretty-hydra.el
@@ -36,7 +36,7 @@
 (require 'hydra)
 
 (defcustom pretty-hydra-enable-use-package t
-  "Enable use-package integration when set to t."
+  "Enable `use-package' integration when set to t."
   :type 'boolean
   :group 'pretty-hydra)
 
@@ -330,12 +330,12 @@ one if specified.  Arguments are the same as `pretty-hydra-define'."
 
 (defface pretty-hydra-toggle-on-face
   '((t (:inherit 'font-lock-keyword-face)))
-  "Face used to render titles for pretty hydra"
+  "Face used to render titles for pretty hydra."
   :group 'pretty-hydra)
 
 (defface pretty-hydra-toggle-off-face
   '((t (:inherit 'font-lock-comment-face)))
-  "Face used to render titles for pretty hydra"
+  "Face used to render titles for pretty hydra."
   :group 'pretty-hydra)
 
 ;;;###autoload

--- a/pretty-hydra.el
+++ b/pretty-hydra.el
@@ -44,8 +44,8 @@
   "Default specification to format the title and body into a hydra docstring.
 It should contain two `%s'. It can be used to customize the
 whitespace around and between the title and the body. It is only
-used if a title is provided. Can be overriden in the
-prett-hydra body via `:title-body-format-spec'."
+used if a title is provided. Can be overridden in the
+pretty-hydra body via `:title-body-format-spec'."
   :type 'string
   :group 'pretty-hydra)
 
@@ -180,10 +180,11 @@ This is used to create the HEADS to be passed to `defhydra'."
        (-map (-lambda ((key cmd _ . opts))
                (-concat (list key cmd) (pretty-hydra--remove-custom-opts opts))))))
 
-(defun pretty-hydra--maybe-add-title (title docstring &optional title-body-format-spec)
-  "Add TITLE to the DOCSTRING if it's not nil, other return DOCSTRING unchanged.
+(defun pretty-hydra--maybe-add-title (title title-body-format-spec docstring)
+  "Add TITLE to DOCSTRING according to TITLE-BODY-FORMAT-SPEC.
 
-TITLE-BODY-FORMAT-SPEC allows to specify how the TITLE and BODY are combined."
+If TITLE-BODY-FORMAT-SPEC is nil, the value of
+`pretty-hydra-default-title-body-format-spec' is used."
   (if (null title)
       docstring
     (let ((format-spec (if title-body-format-spec
@@ -234,10 +235,9 @@ See `pretty-hydra-define' and `pretty-hydra-define+'."
                         #'identity))
          (title-body-format-spec (plist-get body :title-body-format-spec))
          (quit-key  (plist-get body :quit-key))
-         (docstring (->> (pretty-hydra--maybe-add-title
-                          title
-                          (pretty-hydra--gen-body-docstring separator heads-plist)
-                          title-body-format-spec)
+         (docstring (->> heads-plist
+                         (pretty-hydra--gen-body-docstring separator)
+                         (pretty-hydra--maybe-add-title title title-body-format-spec)
                          (funcall formatter)
                          (s-prepend "\n"))) ;; This is required, otherwise the docstring won't show up correctly
          (heads (pretty-hydra--get-heads heads-plist))


### PR DESCRIPTION
Can be specified for each pretty-hydra via `:title-body-format-spec`. Default can be customized via `pretty-hydra-default-title-body-format-spec`.

I use this to customize amount of whitespace and newlines around title. Otherwise, e.g. changing newlines between title and body might be difficult with just `:formatter`. For my original problem that this solves see issue #49 created by me.

My format-spec names are a bit lengthy, I would be open to suggestions how to improve the naming. And if you think this customization can be achieved by other means, feel free to tell me how and close this :)

Solves #49