### PR TITLE
Use `plist-get` and `plist-put` with `#'equal` from Emacs/Compat 29

### DIFF
--- a/major-mode-hydra.el
+++ b/major-mode-hydra.el
@@ -56,8 +56,8 @@ Set to nil to stop generating such heads."
 
 (defun major-mode-hydra--put-if-absent (plist prop val)
   "Set PROP to VAL if it's absent in PLIST."
-  (when (not (lax-plist-get plist prop))
-    (lax-plist-put plist prop val))
+  (when (not (plist-get plist prop #'equal))
+    (plist-put plist prop val #'equal))
   plist)
 
 (defun major-mode-hydra--name-for (mode)
@@ -75,7 +75,7 @@ Overwrite existing hydra if OVERWRITE-P is t, otherwise add new heads to it."
          (title (when (functionp major-mode-hydra-title-generator)
                   (funcall major-mode-hydra-title-generator mode)))
          (body (-> body
-                   (lax-plist-put :hint nil)
+                   (plist-put :hint nil #'equal)
                    (major-mode-hydra--put-if-absent :color 'teal)
                    (major-mode-hydra--put-if-absent :title title)
                    (major-mode-hydra--put-if-absent :separator major-mode-hydra-separator)

--- a/major-mode-hydra.el
+++ b/major-mode-hydra.el
@@ -56,8 +56,8 @@ Set to nil to stop generating such heads."
 
 (defun major-mode-hydra--put-if-absent (plist prop val)
   "Set PROP to VAL if it's absent in PLIST."
-  (when (not (plist-get plist prop #'equal))
-    (plist-put plist prop val #'equal))
+  (when (not (compat-call plist-get plist prop #'equal))
+    (compat-call plist-put plist prop val #'equal))
   plist)
 
 (defun major-mode-hydra--name-for (mode)
@@ -75,7 +75,7 @@ Overwrite existing hydra if OVERWRITE-P is t, otherwise add new heads to it."
          (title (when (functionp major-mode-hydra-title-generator)
                   (funcall major-mode-hydra-title-generator mode)))
          (body (-> body
-                   (plist-put :hint nil #'equal)
+                   (compat-call plist-put :hint nil #'equal)
                    (major-mode-hydra--put-if-absent :color 'teal)
                    (major-mode-hydra--put-if-absent :title title)
                    (major-mode-hydra--put-if-absent :separator major-mode-hydra-separator)

--- a/pretty-hydra.el
+++ b/pretty-hydra.el
@@ -5,7 +5,7 @@
 ;; Author: Jerry Peng <pr2jerry@gmail.com>
 ;; URL: https://github.com/jerrypnz/major-mode-hydra.el
 ;; Version: 0.2.2
-;; Package-Requires: ((hydra "0.15.0") (s "1.12.0") (dash "2.18.0") (emacs "24"))
+;; Package-Requires: ((hydra "0.15.0") (s "1.12.0") (dash "2.18.0") (emacs "24") (compat "29.1.4.1"))
 
 ;; This file is NOT part of GNU Emacs.
 
@@ -31,6 +31,7 @@
 
 ;;; Code:
 
+(require 'compat)
 (require 'dash)
 (require 's)
 (require 'hydra)
@@ -204,10 +205,11 @@ Two heads are considered duplicate if they have the same key."
 The result is a new plist."
   (let ((cols (cl-loop for (key _value) on new by 'cddr collect key)))
     (-reduce-from (lambda (acc x)
-                    (lax-plist-put acc x
-                                   (pretty-hydra--dedupe-heads
-                                    (append (lax-plist-get acc x)
-                                            (lax-plist-get new x)))))
+                    (plist-put acc x
+                               (pretty-hydra--dedupe-heads
+                                (append (plist-get acc x #'equal)
+                                        (plist-get new x #'equal)))
+                               #'equal))
                   old
                   cols)))
 
@@ -230,7 +232,7 @@ See `pretty-hydra-define' and `pretty-hydra-define+'."
                         (append heads (--map (list it nil) quit-key))
                       (append heads `((,quit-key nil))))
                   heads))
-         (body (lax-plist-put body :hint nil)))
+         (body (plist-put body :hint nil #'equal)))
     `(progn
        (eval-and-compile
          (set (defvar ,(intern (format "%S/heads-plist" name))

--- a/pretty-hydra.el
+++ b/pretty-hydra.el
@@ -205,22 +205,22 @@ Two heads are considered duplicate if they have the same key."
 The result is a new plist."
   (let ((cols (cl-loop for (key _value) on new by 'cddr collect key)))
     (-reduce-from (lambda (acc x)
-                    (plist-put acc x
-                               (pretty-hydra--dedupe-heads
-                                (append (plist-get acc x #'equal)
-                                        (plist-get new x #'equal)))
-                               #'equal))
+                    (compat-call plist-put acc x
+                                 (pretty-hydra--dedupe-heads
+                                  (append (compat-call plist-get acc x #'equal)
+                                          (compat-call plist-get new x #'equal)))
+                                 #'equal))
                   old
                   cols)))
 
 (defun pretty-hydra--generate (name body heads-plist)
   "Helper function to generate expressions with given NAME, BODY, HEADS-PLIST.
 See `pretty-hydra-define' and `pretty-hydra-define+'."
-  (let* ((separator (or (plist-get body :separator) "─"))
-         (title     (plist-get body :title))
-         (formatter (or (plist-get body :formatter)
+  (let* ((separator (or (compat-call plist-get body :separator) "─"))
+         (title     (compat-call plist-get body :title))
+         (formatter (or (compat-call plist-get body :formatter)
                         #'identity))
-         (quit-key  (plist-get body :quit-key))
+         (quit-key  (compat-call plist-get body :quit-key))
          (docstring (->> heads-plist
                          (pretty-hydra--gen-body-docstring separator)
                          (pretty-hydra--maybe-add-title title)
@@ -232,7 +232,7 @@ See `pretty-hydra-define' and `pretty-hydra-define+'."
                         (append heads (--map (list it nil) quit-key))
                       (append heads `((,quit-key nil))))
                   heads))
-         (body (plist-put body :hint nil #'equal)))
+         (body (compat-call plist-put body :hint nil #'equal)))
     `(progn
        (eval-and-compile
          (set (defvar ,(intern (format "%S/heads-plist" name))


### PR DESCRIPTION
From Emacs 29 (currently in pretest), `plist-get` and `plist-put` take an optional comparison predicate which we set to `#'equal`. Previously, `lax-plist-get`/`-put` was used for that, but those functions are now marked as obsolete. They still work as wrapper, but give obsoletion warnings. E.g. the new `lax-plist-get` implementation is

``` elisp
(defun lax-plist-get (plist prop)
  "Extract a value from a property list, comparing with `equal'."
  (declare (pure t) (side-effect-free t) (obsolete plist-get "29.1"))
  (plist-get plist prop #'equal))
```

To keep forward-compatibility with older Emacs releases, I added a dependency on [compat](https://elpa.gnu.org/packages/compat.html), which implements the Emacs-29 version of the plist functions and should take care of that, but I didn't explicitly test older releases yet. `compat`  is getting quite whitespread, so I think it's reasonable to add that dependency.