### PR TITLE
Remove newline prefix from generated docstring

### DIFF
--- a/pretty-hydra.el
+++ b/pretty-hydra.el
@@ -240,8 +240,7 @@ See `pretty-hydra-define' and `pretty-hydra-define+'."
          (docstring (->> heads-plist
                          (pretty-hydra--gen-body-docstring separator)
                          (pretty-hydra--maybe-add-title title title-body-format-spec)
-                         (funcall formatter)
-                         (s-prepend "\n"))) ;; This is required, otherwise the docstring won't show up correctly
+                         (funcall formatter)))
          (heads (pretty-hydra--get-heads heads-plist))
          (heads (if quit-key
                     (if (listp quit-key)


### PR DESCRIPTION
This additional newline was added 7 years ago in f25da0e to work around a bug at the time that has likely long been fixed. Today, the newline only made the docstring look off because of the resulting uneven padding at the top and bottom.

**With the old newline**:
![satty-20250310-22:54:05](https://github.com/user-attachments/assets/698879cf-743c-4376-b1f7-ddb23e39e3fa)

**With the unnecessary newline removed**:
![satty-20250310-22:54:32](https://github.com/user-attachments/assets/99b5b7d6-d528-4569-864e-544b63570634)

**With the newline removed and `lv` frontend instead of `posframe`**:
![satty-20250310-23:00:04](https://github.com/user-attachments/assets/c4b67d0a-fd82-451b-8705-845e5c37312a)
